### PR TITLE
- normalizes the string representation by wrapping around smaller units if required

### DIFF
--- a/duration/main.go
+++ b/duration/main.go
@@ -83,7 +83,7 @@ func FromString(dur string) (*Duration, error) {
 			d.Seconds = int(s)
 			d.MilliSeconds = int(milli * 1000)
 		default:
-			return nil, errors.New(fmt.Sprintf("unknown field %s", name))
+			return nil, fmt.Errorf("unknown field %s", name)
 		}
 	}
 
@@ -91,12 +91,12 @@ func FromString(dur string) (*Duration, error) {
 }
 
 // String prints out the value passed in. It's not strictly according to the
-// ISO spec, but it's pretty close. In particular, to completely conform it
-// would need to round up to the next largest unit. 61 seconds to 1 minute 1
-// second, for example. It would also need to disallow weeks mingling with
+// ISO spec, but it's pretty close. It would need to disallow weeks mingling with
 // other units.
 func (d *Duration) String() string {
 	var s bytes.Buffer
+
+	d.normalize()
 
 	err := tmpl.Execute(&s, d)
 	if err != nil {
@@ -104,6 +104,37 @@ func (d *Duration) String() string {
 	}
 
 	return s.String()
+}
+
+func (d *Duration) normalize() {
+	msToS := 1000
+	StoM := 60
+	MtoH := 60
+	HtoD := 24
+	DtoW := 7
+	if d.MilliSeconds >= msToS {
+		d.Seconds += d.MilliSeconds / msToS
+		d.MilliSeconds %= msToS
+	}
+	if d.Seconds >= StoM {
+		d.Minutes += d.Seconds / StoM
+		d.Seconds %= StoM
+	}
+	if d.Minutes >= MtoH {
+		d.Hours += d.Minutes / MtoH
+		d.Minutes %= MtoH
+	}
+	if d.Hours >= HtoD {
+		d.Days += d.Hours / HtoD
+		d.Hours %= HtoD
+	}
+	if d.Days >= DtoW {
+		d.Weeks += d.Days / DtoW
+		d.Days %= DtoW
+	}
+	// a month is not always 30 days, so we don't normalize that
+	// a month is not always 4 weeks, so we don't normalize that
+	// a year is not always 52 weeks, so we don't normalize that
 }
 
 func (d *Duration) HasTimePart() bool {

--- a/duration/main.go
+++ b/duration/main.go
@@ -96,7 +96,7 @@ func FromString(dur string) (*Duration, error) {
 func (d *Duration) String() string {
 	var s bytes.Buffer
 
-	d.normalize()
+	d.Normalize()
 
 	err := tmpl.Execute(&s, d)
 	if err != nil {
@@ -106,7 +106,10 @@ func (d *Duration) String() string {
 	return s.String()
 }
 
-func (d *Duration) normalize() {
+// Normalize makes sure that all fields are represented as the smallest meaningful value possible by dividing them out by the conversion factor to the larger unit.
+// e.g. if you have a duration of 10 day, 25 hour, and 61 minute, it will be normalized to 1 week 5 days, 2 hours, and 1 minute.
+// this function does not normalize days to months, weeks to months or weeks to years as they do not always convert with the same value.
+func (d *Duration) Normalize() {
 	msToS := 1000
 	StoM := 60
 	MtoH := 60
@@ -132,6 +135,7 @@ func (d *Duration) normalize() {
 		d.Weeks += d.Days / DtoW
 		d.Days %= DtoW
 	}
+	//TODO convert 12 months to 1 year when month is supported
 	// a month is not always 30 days, so we don't normalize that
 	// a month is not always 4 weeks, so we don't normalize that
 	// a year is not always 52 weeks, so we don't normalize that
@@ -147,6 +151,7 @@ func (d *Duration) ToDuration() time.Duration {
 
 	tot := time.Duration(0)
 
+	d.Normalize()
 	tot += year * time.Duration(d.Years)
 	tot += day * 7 * time.Duration(d.Weeks)
 	tot += day * time.Duration(d.Days)

--- a/duration/main_test.go
+++ b/duration/main_test.go
@@ -1,0 +1,97 @@
+package duration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestItNormalizesMS(t *testing.T) {
+	// Arrange
+	duration := &Duration{
+		MilliSeconds: 1001,
+	}
+
+	// Act
+	result := duration.String()
+
+	// Assert
+	assert.Equal(t, 1, duration.Seconds)
+	assert.Equal(t, 1, duration.MilliSeconds)
+	assert.Equal(t, "PT1S", result)
+}
+
+func TestItNormalizesS(t *testing.T) {
+	// Arrange
+	duration := &Duration{
+		Seconds: 61,
+	}
+
+	// Act
+	result := duration.String()
+
+	// Assert
+	assert.Equal(t, 1, duration.Seconds)
+	assert.Equal(t, 1, duration.Minutes)
+	assert.Equal(t, "PT1M1S", result)
+}
+
+func TestItNormalizesM(t *testing.T) {
+	// Arrange
+	duration := &Duration{
+		Minutes: 61,
+	}
+
+	// Act
+	result := duration.String()
+
+	// Assert
+	assert.Equal(t, 1, duration.Hours)
+	assert.Equal(t, 1, duration.Minutes)
+	assert.Equal(t, "PT1H1M", result)
+}
+
+func TestItNormalizesH(t *testing.T) {
+	// Arrange
+	duration := &Duration{
+		Hours: 25,
+	}
+
+	// Act
+	result := duration.String()
+
+	// Assert
+	assert.Equal(t, 1, duration.Hours)
+	assert.Equal(t, 1, duration.Days)
+	assert.Equal(t, "P1DT1H", result)
+}
+
+func TestItNormalizesD(t *testing.T) {
+	// Arrange
+	duration := &Duration{
+		Days: 8,
+	}
+
+	// Act
+	result := duration.String()
+
+	// Assert
+	assert.Equal(t, 1, duration.Weeks)
+	assert.Equal(t, 1, duration.Days)
+	assert.Equal(t, "P1W1D", result)
+}
+
+func TestItDoesntNormalizesW(t *testing.T) {
+	// Arrange
+	duration := &Duration{
+		Days: 56,
+	}
+
+	// Act
+	result := duration.String()
+
+	// Assert
+	assert.Equal(t, 56, duration.Weeks)
+	assert.Equal(t, 0, duration.Years)
+	assert.Equal(t, "P56W", result)
+}

--- a/duration/main_test.go
+++ b/duration/main_test.go
@@ -84,7 +84,7 @@ func TestItNormalizesD(t *testing.T) {
 func TestItDoesntNormalizesW(t *testing.T) {
 	// Arrange
 	duration := &Duration{
-		Days: 56,
+		Weeks: 56,
 	}
 
 	// Act


### PR DESCRIPTION
# Description

This PR adds a normalize function to wrap around smaller units when required.
I was wondering whether it should be exposed publicly so users can call it themselves should they want need to?
I was also wondering whether it should be called in the "ToDuration" method?
Thanks for reviewing it!

## Type of change

Please delete options that are not relevant.

- [ ] Documentation Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (go test) that prove my fix is effective or that my feature works
